### PR TITLE
FIX: Signup code validation

### DIFF
--- a/src/lib/server/utils.ts
+++ b/src/lib/server/utils.ts
@@ -20,7 +20,7 @@ export function constantTimeEqualString(a: string, b: string): boolean {
 		return false;
 	}
 	const aBytes = new TextEncoder().encode(a);
-	const bBytes = new TextEncoder().encode(a);
+	const bBytes = new TextEncoder().encode(b);
 	const equal = constantTimeEqual(aBytes, bBytes);
 	return equal;
 }


### PR DESCRIPTION
Currently, the `/signup/user` endpoint responds with success whenever an 8-character code is provided, without validating it against the code that was sent.